### PR TITLE
Make exp/log rewrites dtype-safe under cast_policy="numpy+floatX"

### DIFF
--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -551,7 +551,9 @@ def local_exp_log(fgraph, node):
     # Case for exp(softplus(x)) aka exp(log1pexp) -> 1 + exp(x)
     if isinstance(prev_op, ps_math.Softplus) and isinstance(node_op, ps.Exp):
         x = x.owner.inputs[0]
-        return [add(1, exp(x))]
+        old_out = node.outputs[0]
+        one_cast = np.asarray(1, dtype=old_out.dtype)
+        return [add(one_cast, exp(x))]
 
     # Case for expm1(softplus(x)) aka expm1(log1pexp) -> exp(x)
     if isinstance(prev_op, ps_math.Softplus) and isinstance(node_op, ps.Expm1):
@@ -636,14 +638,16 @@ def local_exp_log_nan_switch(fgraph, node):
     if isinstance(prev_op, ps.Log1p) and isinstance(node_op, ps.Exp):
         x = x.owner.inputs[0]
         old_out = node.outputs[0]
-        new_out = switch(ge(x, -1), add(1, x), np.asarray(np.nan, old_out.dtype))
+        one_cast = np.asarray(1, dtype=old_out.dtype)
+        new_out = switch(ge(x, -1), add(one_cast, x), np.asarray(np.nan, old_out.dtype))
         return [new_out]
 
     # Case for expm1(log(x)) -> x - 1
     if isinstance(prev_op, ps.Log) and isinstance(node_op, ps.Expm1):
         x = x.owner.inputs[0]
         old_out = node.outputs[0]
-        new_out = switch(ge(x, 0), sub(x, 1), np.asarray(np.nan, old_out.dtype))
+        one_cast = np.asarray(1, dtype=old_out.dtype)
+        new_out = switch(ge(x, 0), sub(x, one_cast), np.asarray(np.nan, old_out.dtype))
         return [new_out]
 
     # Case for expm1(log1p(x)) -> x
@@ -657,7 +661,8 @@ def local_exp_log_nan_switch(fgraph, node):
     if isinstance(prev_op, ps_math.Log1mexp) and isinstance(node_op, ps.Exp):
         x = x.owner.inputs[0]
         old_out = node.outputs[0]
-        new_out = switch(le(x, 0), sub(1, exp(x)), np.asarray(np.nan, old_out.dtype))
+        one_cast = np.asarray(1, dtype=old_out.dtype)
+        new_out = switch(le(x, 0), sub(one_cast, exp(x)), np.asarray(np.nan, old_out.dtype))
         return [new_out]
 
     # Case for expm1(log1mexp(x)) -> -exp(x)
@@ -3488,11 +3493,14 @@ def local_exp_over_1_plus_exp(fgraph, node):
     copy_stack_trace(num, new_num)
 
     if len(denom_rest) == 0:
-        return [new_num]
+        out = new_num
     elif len(denom_rest) == 1:
         out = new_num / denom_rest[0]
     else:
         out = new_num / mul(*denom_rest)
+
+    if out.dtype != node.outputs[0].dtype:
+        out = cast(out, node.outputs[0].dtype)
 
     copy_stack_trace(node.outputs[0], out)
     return [out]

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -5170,6 +5170,30 @@ def test_log_div_non_constant_not_rewritten():
 
 
 @pytest.mark.parametrize(
+    "build, removed_op",
+    [
+        (lambda x: pt.exp(pt.softplus(x)), "Softplus"),  # local_exp_log: 1 + exp(x)
+        (lambda x: pt.exp(pt.log1p(x)), "Log1p"),  # local_exp_log_nan_switch: 1 + x
+        (lambda x: pt.expm1(pt.log(x)), "Log"),  # local_exp_log_nan_switch: x - 1
+        (lambda x: pt.exp(pt.log1mexp(x)), "Log1mexp"),  # nan_switch: 1 - exp(x)
+    ],
+)
+def test_exp_log_rewrites_apply_under_numpy_floatX(build, removed_op):
+    # Regression for #1073: these rewrites were silently skipped under numpy+floatX.
+    with config.change_flags(cast_policy="numpy+floatX"):
+        x = pt.vector("x", dtype="float32")
+        fgraph = function([x], build(x)).maker.fgraph
+        op_names = set()
+        for node in fgraph.toposort():
+            scalar_op = getattr(node.op, "scalar_op", None)
+            op_names.add(type(scalar_op or node.op).__name__)
+            inner = getattr(scalar_op, "fgraph", None)
+            if inner is not None:  # a skipped rewrite leaves the op inside the Composite
+                op_names.update(type(n.op).__name__ for n in inner.toposort())
+    assert removed_op not in op_names
+
+
+@pytest.mark.parametrize(
     "build, expected_fn",
     [
         (lambda x: pt.sign(3.0 / x), lambda x: pt.sign(x)),


### PR DESCRIPTION
Three rewrites — `local_exp_log`, `local_exp_log_nan_switch`, and `local_exp_over_1_plus_exp` — build a constant `1` while rewriting (e.g. `exp(softplus(x)) → 1 + exp(x)`). Under `cast_policy="numpy+floatX"` the bare `1` autocasts to `int64`, which upcasts a float32 graph to float64; the replacement then fails type-checking and the rewrite is silently dropped:

```
<<!! BUG IN FGRAPH.REPLACE !!>> TypeError: Cannot convert Vector(float64) into Vector(float32) ... local_exp_log
```

**Fix:** cast the constant to the node's output dtype (`np.asarray(1, dtype=old_out.dtype)` / `cast(out, node.outputs[0].dtype)`) — the idiom the integer-cast cases in `local_exp_log` already use. No effect under the default `custom` policy.

**Test:** a regression test asserts each rewrite still applies under `numpy+floatX` (the original op is gone from the graph, including inside the fused `Composite`). Default-policy suite unchanged; `ruff` clean.

## Background

Ported from the stalled cast-policy flip pymc-devs/pytensor#1917, which first identified and fixed these rewrites. It prepares for changing the default `cast_policy` to `numpy+floatX` (root cause: pymc-devs/pytensor#1073) and applies the same output-dtype-cast pattern already used for `local_log_div` in pymc-devs/pytensor#2245.
