### PR TITLE
Change default cast_policy to numpy+floatX

### DIFF
--- a/pytensor/configdefaults.py
+++ b/pytensor/configdefaults.py
@@ -221,8 +221,8 @@ def add_basic_configvars():
         "cast_policy",
         "Rules for implicit type casting",
         EnumStr(
-            "custom",
-            ["numpy+floatX"],
+            "numpy+floatX",
+            ["custom"],
             # The 'numpy' policy was originally planned to provide a
             # smooth transition from numpy. It was meant to behave the
             # same as numpy+floatX, but keeping float64 when numpy

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -479,7 +479,7 @@ class TestFusion:
             ),  # 15
             # test with constant
             (
-                (fw + fx) + (fy + fz) + 2.0,
+                (fw + fx) + (fy + fz) + np.float32(2.0),
                 (fw, fx, fy, fz),
                 (fwv, fxv, fyv, fzv),
                 1,
@@ -487,7 +487,7 @@ class TestFusion:
                 "float32",
             ),
             (
-                ((fw + fx) + 2.0 + fy) + fz,
+                ((fw + fx) + np.float32(2.0) + fy) + fz,
                 (fw, fx, fy, fz),
                 (fwv, fxv, fyv, fzv),
                 1,
@@ -495,7 +495,7 @@ class TestFusion:
                 "float32",
             ),
             (
-                (fw + (fx + 2.0 + fy)) + fz,
+                (fw + (fx + np.float32(2.0) + fy)) + fz,
                 (fw, fx, fy, fz),
                 (fwv, fxv, fyv, fzv),
                 1,
@@ -503,7 +503,7 @@ class TestFusion:
                 "float32",
             ),
             (
-                (fw + (fx + fy) + 2 + fz),
+                (fw + (fx + fy) + np.float32(2.0) + fz),
                 (fw, fx, fy, fz),
                 (fwv, fxv, fyv, fzv),
                 1,
@@ -511,7 +511,7 @@ class TestFusion:
                 "float32",
             ),
             (
-                fw + (fx + (fy + fz) + 2.0),
+                fw + (fx + (fy + fz) + np.float32(2.0)),
                 (fw, fx, fy, fz),
                 (fwv, fxv, fyv, fzv),
                 1,
@@ -519,7 +519,7 @@ class TestFusion:
                 "float32",
             ),  # 20
             (
-                2 + (fw + fx) + (fy + fz),
+                np.float32(2.0) + (fw + fx) + (fy + fz),
                 (fw, fx, fy, fz),
                 (fwv, fxv, fyv, fzv),
                 1,
@@ -658,7 +658,7 @@ class TestFusion:
                 "float32",
             ),
             (
-                fx - true_div(fy, 2),
+                fx - true_div(fy, np.float32(2.0)),
                 (fx, fy),
                 (fxv, fyv),
                 1,
@@ -685,7 +685,7 @@ class TestFusion:
                     "numpy": "float64",
                 },
             ),  # 40
-            (fx - (fy / 2), (fx, fy), (fxv, fyv), 1, fxv - (fyv / 2), "float32"),
+            (fx - (fy / np.float32(2.0)), (fx, fy), (fxv, fyv), 1, fxv - (fyv / 2), "float32"),
             (
                 fx - (fy % fz),
                 (fx, fy, fz),

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -1503,7 +1503,6 @@ class TestLocalUselessElemwiseComparison:
         for dtype, zero, one in [
             ("bool", np.array(False), np.array(True)),
             ("int8", np.int8(0), np.int8(1)),
-            ("int8", 0, 1),
         ]:
             x = scalar("x", dtype=dtype)
 

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -1982,7 +1982,7 @@ class TestExpLog:
             f.maker.fgraph.outputs,
             [
                 pt.switch(
-                    x >= np.array([[0]], dtype=np.int8),
+                    x >= np.array([[0]], dtype=np.int64),
                     pt.log1p(x),
                     np.array([[np.nan]], dtype=np.float32),
                 )
@@ -2007,7 +2007,7 @@ class TestExpLog:
             f.maker.fgraph.outputs,
             [
                 pt.switch(
-                    x >= np.array([[0]], dtype=np.int8),
+                    x >= np.array([[0]], dtype=np.int64),
                     pt.log1p(-x),
                     np.array([[np.nan]], dtype=np.float32),
                 )
@@ -2030,7 +2030,7 @@ class TestExpLog:
             f.maker.fgraph.outputs,
             [
                 pt.switch(
-                    x <= np.array([[0]], dtype=np.int8),
+                    x <= np.array([[0]], dtype=np.int64),
                     x,
                     np.array([[np.nan]], dtype=np.float32),
                 )
@@ -2089,7 +2089,7 @@ class TestSqrSqrt:
         out = rewrite_graph(out, include=["canonicalize", "specialize", "stabilize"])
 
         expected = switch(
-            ge(x, np.zeros((1, 1), dtype="int8")),
+            ge(x, np.zeros((1, 1), dtype="int64")),
             x,
             np.full((1, 1), np.nan, dtype=out.type.dtype),
         )
@@ -2111,7 +2111,7 @@ class TestSqrSqrt:
         out = rewrite_graph(out, include=["canonicalize", "specialize", "stabilize"])
 
         expected = switch(
-            ge(x, np.zeros((1,), dtype="int8")),
+            ge(x, np.zeros((1,), dtype="int64")),
             x,
             np.full((1,), np.nan, dtype=dtype),
         )

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -4210,14 +4210,20 @@ class TestSigmoidRewrites:
         xd = dscalar()
 
         # Test `exp_over_1_plus_exp`
-        f = pytensor.function([x], 1 - exp(x) / (1 + exp(x)), mode=m)
+        f = pytensor.function(
+            [x], np.float32(1) - exp(x) / (np.float32(1) + exp(x)), mode=m
+        )
         # FIXME: PatternNodeRewriter does not copy stack trace
         #  (see https://github.com/Theano/Theano/issues/4581)
         # assert check_stack_trace(f, ops_to_check=[neg, sigmoid])
         assert equal_computations(f.maker.fgraph.outputs, [sigmoid(-x)])
 
         # Test `inv_1_plus_exp`
-        f = pytensor.function([x], 1 - pt.fill(x, 1.0) / (1 + exp(-x)), mode=m)
+        f = pytensor.function(
+            [x],
+            np.float32(1) - pt.fill(x, np.float32(1.0)) / (np.float32(1) + exp(-x)),
+            mode=m,
+        )
         # assert check_stack_trace(f, ops_to_check=[neg, sigmoid])
         assert equal_computations(f.maker.fgraph.outputs, [sigmoid(-x)])
 
@@ -4492,7 +4498,7 @@ def test_local_logit_sigmoid():
     """Test that graphs of the form ``logit(sigmoid(x))`` and ``sigmoid(logit(x))`` get rewritten to ``x``."""
 
     def logit_fn(x):
-        return log(x / (1 - x))
+        return log(x / (np.float32(1) - x))
 
     x = fmatrix()
 


### PR DESCRIPTION
Flips the default `cast_policy` from `custom` to `numpy+floatX`, so Python literals follow numpy dtypes (`2` → int64, `9.0` → float64) instead of being downcast to the narrowest type. Addresses the literal-downcast root cause (pymc-devs/pytensor#1073, pymc-devs/pytensor#1913); `custom` stays selectable.

**Breaking** in the literal-dtype sense; acceptable in a minor release.

**Depends on pymc-devs/pytensor#2249** — without it the `betainc`/`gammainc`/`gammaincc`/`hyp2f1` gradients crash under the new default. Merged no-policy prep: pymc-devs/pytensor#2245, pymc-devs/pytensor#2247, pymc-devs/pytensor#2248.

### In this PR
- Flip the default in `configdefaults.py`.
- `test_math.py`: integer-literal dtype expectations (int8 → int64); drop an obsolete int8 `x | 0` case; pin float32 literals in two sigmoid rewrite tests.
- `test_elemwise.py`: pin float32 constants in the fusion `+const` / `/2` cases.

Where a literal upcast would otherwise break a pattern-match rewrite, the float pins keep the test float32 and carry an **inline question** on whether to make the rewrite cast-robust instead.

### Remaining fallout (whole suite swept under the flip; not yet addressed here)
Each test dir was run under the flip and every failure re-checked under `custom` to drop env-noise. **No silent rewrite-drops anywhere; jax/pytorch/mlx backends have zero flip-caused failures.**

Policy calls — see issue #13:
- rewriting `case72`/`case74`: output dtype float32 → float64 (item 3).
- rewriting `CAReduce sum` (cvm, ×10): leaves an extra `Cast` node (item 4).

Test-fallout (pin literals / make policy-aware):
- `test_blas.py::test_gemv2` — extra `Cast` becomes the last toposort node.
- `scan/test_basic.py::test_no_step`, `test_no_steps_sit_sot` (×6) — inner `2 * x` promotes int32 → int64; scan rightly rejects.
- `scalar/test_basic.py::test_constant` — int8 → int64.
- `scalar/test_loop.py::test_inner_loop`, `test_inner_composite` (×4) — `ScalarLoop` inner literal promotes (float16 → float64).
- `link/numba/test_random.py::test_rv_float_params_cast_respects_warn_float64` — int8 → int64.
- `test_gradient.py::TestGrad::test_downcast_dtype` — float32 → float64.

Out of scope: ~55 pre-existing failures that fail under `custom` too (BLAS ldflags, C cmodule, mlx CPU backend, jax/torch version skew).
