### PR TITLE
Fix dtype handling for integer literals with cast_policy

### DIFF
--- a/pytensor/tensor/rewriting/blas.py
+++ b/pytensor/tensor/rewriting/blas.py
@@ -355,7 +355,13 @@ def _gemm_from_factored_list(fgraph, lst):
         # sM can be a tuple of 2 elements or an PyTensor variable.
         if isinstance(sM, tuple):
             sm0, sm1 = sM
-            sm0 = ptb.as_tensor_variable(sm0)
+            if isinstance(sm0, int | float):
+                # Python literal scales (the +/-1.0 seeded by
+                # `_gemm_canonicalize`) adopt the matrix dtype instead of
+                # following the autocast policy
+                sm0 = ptb.as_tensor_variable(np.asarray(sm0, dtype=sm1.dtype))
+            else:
+                sm0 = ptb.as_tensor_variable(sm0)
             if pytensor.scalar.upcast(sm0.dtype, sm1.dtype) == sm1.dtype:
                 lst2.append((ptb.cast(sm0, sm1.dtype), sM[1]))
 

--- a/tests/link/numba/test_random.py
+++ b/tests/link/numba/test_random.py
@@ -797,7 +797,7 @@ def test_rv_float_params_cast_to_float64(floatX):
     with pytensor.config.change_flags(floatX=floatX):
         rng = shared(np.random.default_rng(123))
 
-        # Opt-in: the int8 literals 0, 1 become float64 regardless of floatX.
+        # Opt-in: the integer literals 0, 1 become float64 regardless of floatX.
         assert _compiled_rv_dist_param_dtypes(
             pt.random.normal(0, 1, size=(5,), rng=rng)
         ) == ["float64", "float64"]
@@ -825,9 +825,10 @@ def test_rv_float_params_cast_to_float64(floatX):
 
 def test_rv_float_params_cast_respects_warn_float64():
     # When the user asked to be warned/raised on float64, the rewrite must not silently
-    # introduce it; the int8 params are left as-is.
+    # introduce it; the integer params are left as-is.
+    int_dtype = "int8" if pytensor.config.cast_policy == "custom" else "int64"
     with pytensor.config.change_flags(floatX="float32", warn_float64="raise"):
         rng = shared(np.random.default_rng(123))
         assert _compiled_rv_dist_param_dtypes(
             pt.random.normal(0, 1, size=(5,), rng=rng)
-        ) == ["int8", "int8"]
+        ) == [int_dtype, int_dtype]

--- a/tests/scalar/test_basic.py
+++ b/tests/scalar/test_basic.py
@@ -467,7 +467,8 @@ def test_grad_abs():
 def test_constant():
     c = constant(2, name="a")
     assert c.name == "a"
-    assert c.dtype == "int8"
+    expected = "int8" if pytensor.config.cast_policy == "custom" else "int64"
+    assert c.dtype == expected
     c = constant(2, dtype="float32")
     assert c.name is None
     assert c.dtype == "float32"

--- a/tests/scalar/test_loop.py
+++ b/tests/scalar/test_loop.py
@@ -202,7 +202,7 @@ def test_inner_composite(mode):
     n_steps = int64("n_steps")
     x = float64("x")
 
-    one = Composite([x], [cos(exp(x)) ** 2 + sin(exp(x)) ** 2])(x)
+    one = Composite([x], [cos(exp(x)) ** np.int8(2) + sin(exp(x)) ** np.int8(2)])(x)
 
     op = ScalarLoop(init=[x], update=[one + x])
     y = op(n_steps, x)
@@ -234,7 +234,7 @@ def test_inner_loop(mode):
     x = float64("x")
 
     x_in = float64("x_in")
-    inner_loop_op = ScalarLoop(init=[x_in], update=[x_in + 1])
+    inner_loop_op = ScalarLoop(init=[x_in], update=[x_in + np.int8(1)])
 
     outer_loop_op = ScalarLoop(
         init=[x], update=[inner_loop_op(n_steps, x)], constant=[n_steps]

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -404,7 +404,7 @@ class TestScan:
         """We expect an empty output array when ``n_steps == 0``."""
 
         def f_pow(x_tm1):
-            return 2 * x_tm1
+            return np.int8(2) * x_tm1
 
         n_steps = iscalar("n_steps")
         values = scan(
@@ -439,7 +439,7 @@ class TestScan:
         """We expect an empty output array when scanning over an empty sequence."""
 
         def inner_fn(x_seq, x_i):
-            return 2 * x_i
+            return np.int8(2) * x_i
 
         with config.change_flags(mode=mode):
             values = scan(

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -685,7 +685,14 @@ class TestFusion:
                     "numpy": "float64",
                 },
             ),  # 40
-            (fx - (fy / np.float32(2.0)), (fx, fy), (fxv, fyv), 1, fxv - (fyv / 2), "float32"),
+            (
+                fx - (fy / np.float32(2.0)),
+                (fx, fy),
+                (fxv, fyv),
+                1,
+                fxv - (fyv / 2),
+                "float32",
+            ),
             (
                 fx - (fy % fz),
                 (fx, fy, fz),
@@ -964,7 +971,10 @@ class TestFusion:
                     np.sum(-((fxv - fyv) ** 2) / 2),
                     -(fxv - fyv),
                 ),
-                ("float32", "float32"),
+                {
+                    "custom": ("float32", "float32"),
+                    "numpy+floatX": (config.floatX, "float32"),
+                },
             ),
             # Two Composite graphs that share the same input, but are split by
             # a non-elemwise operation (Assert)
@@ -1002,7 +1012,10 @@ class TestFusion:
                 (fxv,),
                 4,
                 (np.sum(fxv + 5) * np.exp(fxv) / (fxv + 5),),
-                ("float32",),
+                {
+                    "custom": ("float32",),
+                    "numpy+floatX": (config.floatX,),
+                },
             ),
             (
                 (sin(exp(fx)), exp(sin(fx))),

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -193,6 +193,11 @@ def inputs(xbc=(0, 0), ybc=(0, 0), zbc=(0, 0)):
     return x, y, z
 
 
+def _autocast_int_dtype():
+    """dtype the active cast_policy gives a small Python int literal."""
+    return "int8" if config.cast_policy == "custom" else "int64"
+
+
 def test_add_canonizer_problem0():
     n_segments = 10
     label = lscalar("label")
@@ -1981,7 +1986,7 @@ class TestExpLog:
             f.maker.fgraph.outputs,
             [
                 pt.switch(
-                    x >= np.array([[0]], dtype=np.int64),
+                    x >= np.array([[0]], dtype=_autocast_int_dtype()),
                     pt.log1p(x),
                     np.array([[np.nan]], dtype=np.float32),
                 )
@@ -2006,7 +2011,7 @@ class TestExpLog:
             f.maker.fgraph.outputs,
             [
                 pt.switch(
-                    x >= np.array([[0]], dtype=np.int64),
+                    x >= np.array([[0]], dtype=_autocast_int_dtype()),
                     pt.log1p(-x),
                     np.array([[np.nan]], dtype=np.float32),
                 )
@@ -2029,7 +2034,7 @@ class TestExpLog:
             f.maker.fgraph.outputs,
             [
                 pt.switch(
-                    x <= np.array([[0]], dtype=np.int64),
+                    x <= np.array([[0]], dtype=_autocast_int_dtype()),
                     x,
                     np.array([[np.nan]], dtype=np.float32),
                 )
@@ -2088,7 +2093,7 @@ class TestSqrSqrt:
         out = rewrite_graph(out, include=["canonicalize", "specialize", "stabilize"])
 
         expected = switch(
-            ge(x, np.zeros((1, 1), dtype="int64")),
+            ge(x, np.zeros((1, 1), dtype=_autocast_int_dtype())),
             x,
             np.full((1, 1), np.nan, dtype=out.type.dtype),
         )
@@ -2110,7 +2115,7 @@ class TestSqrSqrt:
         out = rewrite_graph(out, include=["canonicalize", "specialize", "stabilize"])
 
         expected = switch(
-            ge(x, np.zeros((1,), dtype="int64")),
+            ge(x, np.zeros((1,), dtype=_autocast_int_dtype())),
             x,
             np.full((1,), np.nan, dtype=dtype),
         )

--- a/tests/tensor/test_blas.py
+++ b/tests/tensor/test_blas.py
@@ -1281,7 +1281,8 @@ class TestGemv(unittest_tools.OptimizationTestMixin):
         self.t_gemv1((3, 0))
         self.t_gemv1((0, 0))
 
-    def test_gemv2(self):
+    @pytest.mark.parametrize("cast_policy", ["custom", "numpy+floatX"])
+    def test_gemv2(self, cast_policy):
         # test vector2+dot(vector1,matrix)
         rng = np.random.default_rng(unittest_tools.fetch_seed())
         v1 = shared(np.array(rng.uniform(size=(2,)), dtype="float32"))
@@ -1289,7 +1290,8 @@ class TestGemv(unittest_tools.OptimizationTestMixin):
         v2 = shared(v2_orig)
         m = shared(np.array(rng.uniform(size=(2, 3)), dtype="float32"))
 
-        f = function([], v2 + pytensor.tensor.dot(v1, m), mode=mode_blas_opt)
+        with config.change_flags(cast_policy=cast_policy):
+            f = function([], v2 + pytensor.tensor.dot(v1, m), mode=mode_blas_opt)
 
         # Assert they produce the same output
         assert np.allclose(f(), np.dot(v1.get_value(), m.get_value()) + v2.get_value())
@@ -1298,9 +1300,13 @@ class TestGemv(unittest_tools.OptimizationTestMixin):
         assert topo[-1].op.inplace is False
 
         # test the inplace version
-        g = function(
-            [], [], updates=[(v2, v2 + pytensor.tensor.dot(v1, m))], mode=mode_blas_opt
-        )
+        with config.change_flags(cast_policy=cast_policy):
+            g = function(
+                [],
+                [],
+                updates=[(v2, v2 + pytensor.tensor.dot(v1, m))],
+                mode=mode_blas_opt,
+            )
 
         # Assert they produce the same output
         g()

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -570,7 +570,7 @@ class TestGrad:
         # get upcasted to float64.
         # x has dtype float32, regardless of the value of floatX
         x = fscalar("x")
-        y = x * 2
+        y = x * np.float32(2)
         z = lscalar("z")
 
         c = y + z


### PR DESCRIPTION
## Description

Follow-up to #12 (stacked on its branch): resolves the open policy items and clears the remaining test fallout listed there, per ricardoV94's guidance on the upstream threads (pymc-devs/pytensor#1073, #1913, #2245, #2247, #2248).

### Real fix: gemm/gemv fusion silently dropped (`afd4d99`)

What #12 listed as "test_gemv2: extra Cast in toposort" is actually a rewrite regression: under `cast_policy="numpy+floatX"`, the `+/-1.0` scale seeded by `_gemm_canonicalize` autocasts to float64, fails the upcast check in `_gemm_from_factored_list`, and the whole gemm/gemv candidate is discarded — `v2 + dot(v1, m)` kept a separate `Add` instead of folding beta into `Gemv`. Fixed by building literal scales with the matrix dtype (the pymc-devs/pytensor#2245/#2247 idiom); no-op under `custom`. `test_gemv2` is parametrized on `cast_policy` per the #2247 pattern. Extractable as a standalone upstream prep PR (issue #13 item 6).

### Issue #13 decisions implemented

- **Item 3** (`2998b1b`): fusion cases 72/74 assert the honest per-policy dtype via the existing dict-keyed `out_dtype` convention (`{"custom": "float32", "numpy+floatX": config.floatX}`).
- **Item 4**: not reproducible anymore — `test_CAReduce_single_input` passes under the flip for both floatX settings; no action.
- **Item 2**: the float32 pins from #12 stay as the documented interim (option C); the three inline threads on #12 are answered accordingly.

### Remaining test fallout from #12 (`6f98b8f`)

- scan `test_no_step`/`test_no_steps_sit_sot`: pin the inner `2 * x` literal to int8 so the state dtype is preserved
- scalar `test_loop`: pin inner-graph literals so the float16 rebuild keeps update dtype == init dtype
- scalar `test_constant`, numba `test_rv_float_params_cast_respects_warn_float64`: policy-aware int64 expectation
- `test_downcast_dtype`: pin `y = x * np.float32(2)` so the grad-downcast mechanism stays exercised now that `x * 2` legitimately promotes

### Both-policy regression found in #12's own commits (`56633b3`)

Full `rewriting/test_math.py` under `cast_policy=custom` caught 5 failures from `a745a79`: the `int64` switch-constants hard-coded into `TestExpLog`/`TestSqrSqrt` expected graphs only hold under `numpy+floatX`. They now derive the expected dtype from the active policy via `_autocast_int_dtype()`.

### Verification

`rewriting/test_math.py`, `rewriting/test_elemwise.py`, `test_gradient.py`, `scalar/`, scan no-step tests, blas gemv/gemm subset, numba rv-param tests — all green under **both** `numpy+floatX` and `custom`. Note: fork `main` predates upstream pymc-devs/pytensor#2249 (merged Jun 21), so the betainc/gammainc gradient tests still need a `main` sync.

## Related Issue

- Related to #12, #13, pymc-devs/pytensor#1073, pymc-devs/pytensor#1913

## Checklist

- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective
- [x] Each commit corresponds to relevant logical changes

## Type of change

- [x] Bug fix
- [x] Maintenance

https://claude.ai/code/session_01FWXc59vTjFTLDybuDBypB5